### PR TITLE
tcprint: add a sub-crate for colorized terminal printing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,7 @@ dependencies = [
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tcprint 0.1.0",
  "tempfile 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "timeago 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -748,6 +749,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "tcprint"
+version = "0.1.0"
+dependencies = [
+ "termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -758,6 +766,14 @@ dependencies = [
  "redox_syscall 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -921,9 +937,26 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "wincolor"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "xdg"
@@ -1039,6 +1072,7 @@ dependencies = [
 "checksum syn 0.15.22 (registry+https://github.com/rust-lang/crates.io-index)" = "ae8b29eb5210bc5cf63ed6149cbf9adfc82ac0be023d8735c176ee74a2db4da7"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum tempfile 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "55c1195ef8513f3273d55ff59fe5da6940287a0d7a98331254397f464833675b"
+"checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
 "checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
@@ -1062,6 +1096,8 @@ dependencies = [
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "afc5508759c5bf4285e61feb862b6083c8480aec864fa17a81fdec6f69b461ab"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+"checksum wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "561ed901ae465d6185fa7864d63fbd5720d0ef718366c9a4dc83cf6170d7e9ba"
 "checksum xdg 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d089681aa106a86fade1b0128fb5daf07d5867a509ab036d99988dec80429a57"
 "checksum yup-oauth2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "66f8b1fe29c69b1056e5eb461630ce689d2c075bef4a07c0808b95373af887d8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ serde = "^1.0"
 serde_derive = "^1.0"
 serde_json = "^1.0"
 structopt = "0.2"
+tcprint = { path = "tcprint", version = "0.1" }
 tempfile = "^3.0"
 timeago = "^0.1"
 url = "^1.7"

--- a/src/app.rs
+++ b/src/app.rs
@@ -7,6 +7,7 @@ use diesel::prelude::*;
 use diesel::sqlite::SqliteConnection;
 use petgraph::prelude::*;
 use std::collections::HashMap;
+use tcprint::{BasicColors, ColorPrintState};
 use yup_oauth2::ApplicationSecret;
 
 use accounts::{self, Account};
@@ -23,6 +24,9 @@ pub struct Application {
 
     /// Our connection to the database of document information.
     pub conn: SqliteConnection,
+
+    /// The state object for colorized terminal output.
+    pub ps: ColorPrintState<BasicColors>,
 }
 
 
@@ -31,10 +35,12 @@ impl Application {
     pub fn initialize() -> Result<Application> {
         let secret = google_apis::get_app_secret()?;
         let conn = database::get_db_connection()?;
+        let ps = ColorPrintState::default();
 
         Ok(Application {
             secret,
-            conn
+            conn,
+            ps
         })
     }
 

--- a/tcprint/Cargo.toml
+++ b/tcprint/Cargo.toml
@@ -1,0 +1,16 @@
+# Copyright 2018 Peter Williams <peter@newton.cx>
+# Licensed under the MIT License.
+
+[package]
+name = "tcprint"
+version = "0.1.0"
+authors = ["Peter Williams <peter@newton.cx>"]
+description = "Structured, colorized printing to the terminal using `termcolor`"
+homepage = "https://github.com/pkgw/drorg"
+documentation = "https://docs.rs/crate/tcprint"
+repository = "https://github.com/pkgw/drorg"
+readme = "README.md"
+license = "MIT"
+
+[dependencies]
+termcolor = "1.0"

--- a/tcprint/README.md
+++ b/tcprint/README.md
@@ -1,0 +1,11 @@
+# tcprint
+
+Structured, colorized printing to the terminal using
+[termcolor](https://github.com/BurntSushi/termcolor).
+
+
+## Copyright and License
+
+Copyright 2018 Peter Williams. Licensed under the MIT License. All
+contributions to this project will be assumed to be licensed under the same
+terms, unless explicitly otherwise stated.

--- a/tcprint/src/lib.rs
+++ b/tcprint/src/lib.rs
@@ -1,0 +1,283 @@
+// Copyright 2018 Peter Williams <peter@newton.cx>
+// Licensed under the MIT License.
+
+//! Structured, colorized printing to the terminal using
+//! [termcolor](https://github.com/BurntSushi/termcolor).
+//!
+//! **Real docs TODO**.
+//!
+//! This module is designed to be helpful without requiring any special code,
+//! but it is extensible if you want to add features.
+//!
+//! ```
+//! use tcprint::{BasicColors, ColorPrintState};
+//! let mut state = ColorPrintState::<BasicColors>::default();
+//!
+//! let q = 17;
+//! tcprint!(state, [red: "oh no:"], ("q is: {}", q));
+//! ```
+
+#![deny(missing_docs)]
+
+extern crate termcolor;
+
+use std::default::Default;
+use std::fmt;
+use std::io::{self, Write};
+use termcolor::{ColorChoice, StandardStream, WriteColor};
+
+pub use termcolor::{Color, ColorSpec};
+
+
+/// Which destination to print text to: standard output or standard error.
+///
+/// This enum may seem a bit superfluous, but it's possible that we might want
+/// to extend it with additional variants in the future.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PrintDestination {
+    /// Print to standard error.
+    Stderr,
+
+    /// Print to standard output.
+    Stdout,
+}
+
+
+/// A structure capturing access to all output streams.
+///
+/// Users of this crate shouldn't need to care about this type, but it needs
+/// to be made public so that the underlying macros can work. So it is hidden.
+#[doc(hidden)]
+pub struct PrintStreams {
+    stdout: StandardStream,
+    stderr: StandardStream,
+}
+
+impl Default for PrintStreams {
+    fn default() -> Self {
+        let stdout = StandardStream::stdout(ColorChoice::Auto);
+        let stderr = StandardStream::stderr(ColorChoice::Auto);
+
+        PrintStreams {
+            stdout,
+            stderr,
+        }
+    }
+}
+
+impl PrintStreams {
+    /// Print colorized output to one (or more) of the output streams.
+    ///
+    /// This is a low-level function, expected to be used by higher-level APIs.
+    #[inline(always)]
+    pub fn print_color(&mut self, stream: PrintDestination, color: &ColorSpec, args: fmt::Arguments)
+        -> Result<(), io::Error>
+    {
+        let stream = match stream {
+            PrintDestination::Stderr => &mut self.stderr,
+            PrintDestination::Stdout => &mut self.stdout,
+        };
+
+        stream.set_color(&color)?;
+        let r = write!(stream, "{}", args);
+        stream.reset()?;
+        r
+    }
+
+
+    /// Print to one (or more) of the output streams without changing the colorization.
+    ///
+    /// This is a low-level function, expected to be used by higher-level APIs.
+    #[inline(always)]
+    pub fn print_nocolor(&mut self, stream: PrintDestination, args: fmt::Arguments)
+        -> Result<(), io::Error>
+    {
+        let stream = match stream {
+            PrintDestination::Stderr => &mut self.stderr,
+            PrintDestination::Stdout => &mut self.stdout,
+        };
+
+        write!(stream, "{}", args)
+    }
+}
+
+
+/// A basic selection of colors for printing to the terminal.
+pub struct BasicColors {
+    /// Bold red.
+    pub red: ColorSpec,
+
+    /// Bold green.
+    pub green: ColorSpec,
+
+    /// Bold yellow.
+    pub yellow: ColorSpec,
+
+    /// "Highlight": bold white .
+    pub hl: ColorSpec,
+}
+
+impl Default for BasicColors {
+    fn default() -> Self {
+        let mut green = ColorSpec::new();
+        green.set_fg(Some(Color::Green)).set_bold(true);
+
+        let mut red = ColorSpec::new();
+        red.set_fg(Some(Color::Red)).set_bold(true);
+
+        let mut yellow = ColorSpec::new();
+        yellow.set_fg(Some(Color::Yellow)).set_bold(true);
+
+        let mut hl = ColorSpec::new();
+        hl.set_bold(true);
+
+        BasicColors {
+            green,
+            red,
+            yellow,
+            hl,
+        }
+    }
+}
+
+
+/// State for colorized printing.
+///
+/// The type parameter `C` should be a structure containing public fields of
+/// type `termcolor::ColorSpec`. These will be accessed inside the macros to
+/// simplify the creation of colorized output.
+#[derive(Default)]
+pub struct ColorPrintState<C> {
+    streams: PrintStreams,
+    colors: C,
+}
+
+impl<C> ColorPrintState<C> {
+    /// Initialize colorized printing state.
+    pub fn new(colors: C) -> Self {
+        let streams = PrintStreams::default();
+        ColorPrintState { streams, colors }
+    }
+
+    /// Work around borrowck/macro issues.
+    #[doc(hidden)]
+    pub fn split_into_components_mut<'a>(&'a mut self) -> (&'a mut PrintStreams, &'a C) {
+        (&mut self.streams, &self.colors)
+    }
+}
+
+
+#[macro_export]
+macro_rules! tcanyprint {
+    (@clause $cps:expr, $dest:expr, [$color:ident : $($fmt_args:expr),*]) => {{
+        let (streams, colors) = $cps.split_into_components_mut();
+        let _r = streams.print_color($dest, &colors.$color, format_args!($($fmt_args),*));
+    }};
+
+    (@clause $cps:expr, $dest:expr, ($($fmt_args:expr),*)) => {{
+        let (streams, _colors) = $cps.split_into_components_mut();
+        let _r = streams.print_nocolor($dest, format_args!($($fmt_args),*));
+    }};
+
+    ($cps:expr, $dest:expr, $($clause:tt),*) => {{
+        $(
+            tcanyprint!(@clause $cps, $dest, $clause);
+        )*
+    }};
+}
+
+
+#[macro_export]
+macro_rules! tcprint {
+    ($cps:expr, $($clause:tt),*) => {{
+        use $crate::PrintDestination;
+        tcanyprint!($cps, PrintDestination::Stdout, $($clause),*)
+    }};
+}
+
+
+#[macro_export]
+macro_rules! etcprint {
+    ($cps:expr, $($clause:tt),*) => {{
+        use $crate::PrintDestination;
+        tcanyprint!($cps, PrintDestination::Stderr, $($clause),*)
+    }};
+}
+
+
+#[macro_export]
+macro_rules! tcprintln {
+    ($cps:expr, $($clause:tt),*) => {{
+        tcprint!($cps, $($clause),*, ("\n"))
+    }};
+}
+
+
+#[macro_export]
+macro_rules! etcprintln {
+    ($cps:expr, $($clause:tt),*) => {{
+        etcprint!($cps, $($clause),*, ("\n"))
+    }};
+}
+
+
+/// A helper enumeration defining differen "report" types.
+///
+/// TODO: Ord, PartialOrd?
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ReportType {
+    /// An informational message.
+    Note,
+
+    /// A warning.
+    Warning,
+
+    /// An error.
+    Error,
+}
+
+
+/// A helper trait for accessing the colors associated with standard "report" types.
+pub trait ReportingColors {
+    /// Get a `termcolor::ColorSpec` to be associated with a report message.
+    fn get_color_for_report(&self, reptype: ReportType) -> &ColorSpec;
+}
+
+impl ReportingColors for BasicColors {
+    fn get_color_for_report(&self, reptype: ReportType) -> &ColorSpec {
+        match reptype {
+            ReportType::Note => &self.green,
+            ReportType::Warning => &self.yellow,
+            ReportType::Error => &self.red,
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! tcreport {
+    (@inner $cps:expr, $type:expr, $prefix:expr, $($fmt_args:expr),*) => {{
+        {
+            use $crate::{PrintDestination, ReportingColors};
+            let (streams, colors) = $cps.split_into_components_mut();
+            let color = colors.get_color_for_report($type);
+            let _r = streams.print_color(PrintDestination::Stdout, color, format_args!($prefix));
+        }
+
+        tcprintln!($cps, (" "), ($($fmt_args),*));
+    }};
+
+    ($cps:expr, note : $($fmt_args:expr),*) => {{
+        use $crate::ReportType;
+        tcreport!(@inner $cps, ReportType::Note, "note:", $($fmt_args),*)
+    }};
+
+    ($cps:expr, warning : $($fmt_args:expr),*) => {{
+        use $crate::ReportType;
+        tcreport!(@inner $cps, ReportType::Warning, "warning:", $($fmt_args),*)
+    }};
+
+    ($cps:expr, error : $($fmt_args:expr),*) => {{
+        use $crate::ReportType;
+        tcreport!(@inner $cps, ReportType::Error, "error:", $($fmt_args),*)
+    }};
+}


### PR DESCRIPTION
I think I've figured out an approach for this that I like: you can write statements that will generate mixed colorization on a line relatively compactly, but it should be extensible in the future if desired.

Lots of polish needed, but I think the foundation is there now.