### PR TITLE
Standardize the cloud-sync policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,7 @@ version = "0.1.0"
 dependencies = [
  "app_dirs 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "google-drive3 1.0.8+20181004 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ license = "MIT"
 [dependencies]
 app_dirs = "^1.2"
 chrono = "0.4"
+clap = "^2.32"
 diesel = { version = "^1.3", features = ["chrono", "sqlite"] }
 failure = "0.1"
 google-drive3 = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 
 [dependencies]
 app_dirs = "^1.2"
-chrono = "0.4"
+chrono = { version = "0.4", features = ["serde"] }
 clap = "^2.32"
 diesel = { version = "^1.3", features = ["chrono", "sqlite"] }
 failure = "0.1"

--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -3,6 +3,7 @@
 
 //! State regarding the logged-in accounts.
 
+use chrono::{DateTime, Utc};
 use serde_json;
 use std::fs;
 use std::path::PathBuf;
@@ -30,6 +31,9 @@ pub struct AccountData {
 
     /// The identifying ID of this account in the SQLite database.
     pub db_id: i32,
+
+    /// The last time this account was successfully synced with the cloud.
+    pub last_sync: Option<DateTime<Utc>>,
 }
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,7 +95,7 @@ impl DrorgInfoOptions {
                 tcprintln!(app.ps, (""));
             }
 
-            tcprintln!(app.ps, [green: "Name:"], ("      {}", doc.name));
+            tcprintln!(app.ps, [hl: "Name:"], ("      "), [green: "{}", doc.name]);
             tcprintln!(app.ps, [hl: "MIME-type:"], (" {}", doc.mime_type));
             tcprintln!(app.ps, [hl: "Modified:"], ("  {}", doc.utc_mod_time().to_rfc3339()));
             tcprintln!(app.ps, [hl: "ID:"], ("        {}", doc.id));


### PR DESCRIPTION
We now remember when we last synced to the cloud, and will resync only if it's been more than 5 minutes since the last sync. The "resync" subcommand has now also become "sync" and gives access to both the regular lightweight sync, and the heavyweight "rebuild" operation.