### PR TITLE
Add a `drorg ls` command.

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -9,10 +9,11 @@ use diesel::sqlite::SqliteConnection;
 use petgraph::prelude::*;
 use std::collections::HashMap;
 use structopt::StructOpt;
-use tcprint::{BasicColors, ColorPrintState};
+use tcprint::ColorPrintState;
 use yup_oauth2::ApplicationSecret;
 
 use accounts::{self, Account};
+use colors::Colors;
 use database::{self, Doc};
 use errors::Result;
 use google_apis;
@@ -56,7 +57,7 @@ pub struct Application {
     pub conn: SqliteConnection,
 
     /// The state object for colorized terminal output.
-    pub ps: ColorPrintState<BasicColors>,
+    pub ps: ColorPrintState<Colors>,
 }
 
 
@@ -339,10 +340,19 @@ impl Application {
                 |_err| "[future?]".to_owned()
             );
 
-            tcprintln!(self.ps,
-                       [red: "%{1:<0$}", n_width, i],
-                       ("  {1:<0$}  {2}", max_name_len, doc.name, ago)
-            );
+            if doc.is_folder() {
+                tcprintln!(self.ps,
+                           [percent_tag: "%{1:<0$}", n_width, i],
+                           ("  "),
+                           [folder: "{1:<0$}", max_name_len, doc.name],
+                           ("  {}", ago)
+                );
+            } else {
+                tcprintln!(self.ps,
+                           [percent_tag: "%{1:<0$}", n_width, i],
+                           ("  {1:<0$}  {2}", max_name_len, doc.name, ago)
+                );
+            }
 
             i += 1;
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -281,6 +281,19 @@ impl Application {
     }
 
 
+    /// Convert an iterator of document IDs into Doc structures
+    ///
+    /// ## Panics
+    ///
+    /// If any of the IDs are not found in the database!
+    pub fn ids_to_docs<I: IntoIterator<Item = V>, V: AsRef<str>>(&mut self, ids: I) -> Vec<Doc> {
+        ids.into_iter().map(|docid| {
+            use schema::docs::dsl::*;
+            docs.filter(id.eq(&docid.as_ref()))
+                .first::<database::Doc>(&self.conn).unwrap()
+        }).collect()
+    }
+
     /// Print out a list of documents.
     ///
     /// Many TODOs!

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -1,0 +1,72 @@
+// Copyright 2018 Peter Williams <peter@newton.cx>
+// Licensed under the MIT License.
+
+//! The color palette for the command line interface.
+
+use tcprint::{Color, ColorSpec, ReportingColors, ReportType};
+
+
+/// The CLI color palette.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Colors {
+    /// Bold green.
+    pub green: ColorSpec,
+
+    /// Bold yellow.
+    pub yellow: ColorSpec,
+
+    /// Bold red.
+    pub red: ColorSpec,
+
+    /// "Highlight": bold white.
+    pub hl: ColorSpec,
+
+    /// The color for a "%NN" document short-hand in a listing;
+    /// defaults to red.
+    pub percent_tag: ColorSpec,
+
+    /// The color for a folder; defaults to bold blue.
+    pub folder: ColorSpec,
+}
+
+
+impl Default for Colors {
+    fn default() -> Self {
+        let mut green = ColorSpec::new();
+        green.set_fg(Some(Color::Green)).set_bold(true);
+
+        let mut yellow = ColorSpec::new();
+        yellow.set_fg(Some(Color::Yellow)).set_bold(true);
+
+        let mut red = ColorSpec::new();
+        red.set_fg(Some(Color::Red)).set_bold(true);
+
+        let mut hl = ColorSpec::new();
+        hl.set_bold(true);
+
+        let mut percent_tag = ColorSpec::new();
+        percent_tag.set_fg(Some(Color::Red));
+
+        let mut folder = ColorSpec::new();
+        folder.set_fg(Some(Color::Blue)).set_bold(true);
+
+        Colors {
+            green,
+            yellow,
+            red,
+            hl,
+            percent_tag,
+            folder,
+        }
+    }
+}
+
+impl ReportingColors for Colors {
+    fn get_color_for_report(&self, reptype: ReportType) -> &ColorSpec {
+        match reptype {
+            ReportType::Info => &self.green,
+            ReportType::Warning => &self.yellow,
+            ReportType::Error => &self.red,
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,10 +30,11 @@ use std::ffi::OsStr;
 use std::process;
 use std::result::Result as StdResult;
 use structopt::StructOpt;
-use tcprint::{BasicColors, ColorPrintState};
+use tcprint::ColorPrintState;
 
 mod accounts;
 mod app;
+mod colors;
 mod database;
 mod errors;
 mod google_apis;
@@ -41,6 +42,7 @@ mod schema;
 mod token_storage;
 
 use app::Application;
+use colors::Colors;
 use errors::Result;
 
 
@@ -440,7 +442,7 @@ pub struct DrorgCli {
 
 
 impl DrorgCli {
-    fn cli(self) -> StdResult<i32, (failure::Error, Option<ColorPrintState<BasicColors>>)> {
+    fn cli(self) -> StdResult<i32, (failure::Error, Option<ColorPrintState<Colors>>)> {
         let mut app = match Application::initialize(self.app_opts) {
             Ok(a) => a,
             Err(e) => return Err((e, None)), // no colors :-(


### PR DESCRIPTION
Unlike `list`, this lists the files that are contained in a folder. Exciting things may happen if the folder is owned by multiple accounts, which I believe may have different opinions as to what the folder's children are.